### PR TITLE
Clarify active vs security support

### DIFF
--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -31,6 +31,12 @@ At any given time, the Wagtail team provides official security support for sever
     Wagtail 2.6, support will be provided for Wagtail 2.5 and Wagtail 2.4. Upon the release of Wagtail 2.6, Wagtail 2.4's security support will end.
 -   The latest long-term support release will receive security updates.
 
+"Security support" means that we only backport fixes for vulnerabilities or
+data-loss issues. Versions still receiving regular bug fixes are said to be
+under **active support**, which generally includes the most recent feature
+release and any current long-term support series. Older releases receive only
+security support.
+
 When new releases are issued for security reasons, the accompanying notice will include a list of affected versions.
 This list is comprised solely of supported versions of Wagtail: older versions may also be affected, but we do not investigate to determine that, and will not issue patches or new releases for those versions.
 

--- a/docs/releases/release_process.md
+++ b/docs/releases/release_process.md
@@ -256,6 +256,12 @@ The branches for the current feature release `stable/A.B.x` and the last LTS rel
 
 The branch for the previous feature release `stable/A.B-1.x` will only include security and data loss fixes.
 
+Branches that continue to receive bug fixes as well as security updates are said
+to be in **active support**. This includes the current feature release branch
+(`stable/A.B.x`) and any supported long-term support branch. Once a branch moves
+to security support mode, only fixes for vulnerabilities or data loss will be
+backported to it.
+
 Bugs fixed on `main` must _also_ be fixed on other applicable branches; this
 means that commits need to cleanly separate bug fixes from feature additions.
 The developer who commits a fix to `main` will be responsible for also applying


### PR DESCRIPTION
Note by Thibaud – provided prompt:

> Could you update our contributor documentations to clarify what "security support" and "active support" mean - what practical differences there might be?

---

## Summary
- document that active support gets bug fixes as well as security updates
- explain that security support only gets fixes for vulnerabilities or data loss

## Testing
- `make lint-docs`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_6862fe4545f88330906e52b0bd688e0b